### PR TITLE
Refactor AdvertService and use AdvertServiceHelper

### DIFF
--- a/src/main/java/com/project/real_estate_project03_team02/payload/mappers/business/AdvertMapper.java
+++ b/src/main/java/com/project/real_estate_project03_team02/payload/mappers/business/AdvertMapper.java
@@ -17,12 +17,7 @@ import java.util.Map;
 @Component
 @RequiredArgsConstructor
 public class AdvertMapper {
-
-
-    //private final ImagesService imagesService;
-
-    private final TourRequestService tourRequestService;
-
+    
     /**
      *
      * @param advertRequest DTO from UI
@@ -57,8 +52,7 @@ public class AdvertMapper {
                 .title(advert.getTitle())
                // .properties(advert.getCategoryId())
                 // find image list by Advert id
-               // .images(advert.)
-            .tourRequests(tourRequestService.findAllByAdvertId(advert.getId()))
+               // .images(advert.)           
                 .build();
 
     }

--- a/src/main/java/com/project/real_estate_project03_team02/service/business/AdvertService.java
+++ b/src/main/java/com/project/real_estate_project03_team02/service/business/AdvertService.java
@@ -9,6 +9,7 @@ import com.project.real_estate_project03_team02.payload.request.business.AdvertR
 import com.project.real_estate_project03_team02.payload.response.business.AdvertResponse;
 import com.project.real_estate_project03_team02.payload.response.message.ResponseMessage;
 import com.project.real_estate_project03_team02.repository.business.AdvertRepository;
+import com.project.real_estate_project03_team02.service.helper.AdvertServiceHelper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -18,11 +19,11 @@ public class AdvertService {
 
     private final AdvertRepository advertRepository;
     private final AdvertMapper advertMapper;
+    private final TourRequestService tourRequestService;
+    private final AdvertServiceHelper advertServiceHelper;
 
 
-    public Advert findById(Long advertId) {
-        return advertRepository.findById(advertId).orElseThrow(()->new ResourceNotFoundException(String.format(ErrorMessages.NOT_FOUND_ADVERT_MESSAGE,advertId)));
-    }
+
 
 
 
@@ -36,10 +37,12 @@ public class AdvertService {
 
         Advert savedAdvert = advertRepository.save(advert);
 
+        AdvertResponse advertResponse = advertMapper.mapAdvertToAdvertResponse(savedAdvert);
+        advertResponse.setTourRequests(tourRequestService.findAllByAdvertId(advert.getId()));
         // we are returning response DTO by mapping the saved version of advert
         return ResponseMessage.<AdvertResponse>builder()
                 .message(SuccessMessages.ADVERT_CREATED)
-                .object(advertMapper.mapAdvertToAdvertResponse(savedAdvert))
+                .object(advertResponse)
                 .build();
 
     }

--- a/src/main/java/com/project/real_estate_project03_team02/service/business/FavoritesService.java
+++ b/src/main/java/com/project/real_estate_project03_team02/service/business/FavoritesService.java
@@ -8,6 +8,7 @@ import com.project.real_estate_project03_team02.payload.mappers.business.AdvertM
 import com.project.real_estate_project03_team02.payload.messages.ErrorMessages;
 import com.project.real_estate_project03_team02.payload.response.business.AdvertResponseForFavorites;
 import com.project.real_estate_project03_team02.repository.business.FavoritesRepository;
+import com.project.real_estate_project03_team02.service.helper.AdvertServiceHelper;
 import com.project.real_estate_project03_team02.service.helper.PageableHelper;
 import com.project.real_estate_project03_team02.service.user.UserService;
 import lombok.RequiredArgsConstructor;
@@ -30,7 +31,7 @@ public class FavoritesService {
 
     private final PageableHelper pageableHelper;
 
-    private final AdvertService advertService;
+    private final AdvertServiceHelper advertServiceHelper;
 
     private final AdvertMapperForFavorites advertMapperForFavorites;
 
@@ -56,7 +57,7 @@ public class FavoritesService {
     public AdvertResponseForFavorites addOrRemoveAdvertOfUser(HttpServletRequest httpServletRequest, Long id) {
         String authenticatedUserEmail = (String) httpServletRequest.getAttribute("username");
         User authenticatedUser = userService.findByEmail(authenticatedUserEmail);
-        Advert advert = advertService.findById(id);
+        Advert advert = advertServiceHelper.findById(id);
 
         Favorite existingFavorite = favoritesRepository.findByUserIdAndAdvertId(authenticatedUser, advert);
 

--- a/src/main/java/com/project/real_estate_project03_team02/service/business/TourRequestService.java
+++ b/src/main/java/com/project/real_estate_project03_team02/service/business/TourRequestService.java
@@ -13,10 +13,12 @@ import com.project.real_estate_project03_team02.payload.request.business.TourReq
 import com.project.real_estate_project03_team02.payload.response.business.TourRequestResponse;
 import com.project.real_estate_project03_team02.payload.response.message.ResponseMessage;
 import com.project.real_estate_project03_team02.repository.business.TourRequestRepository;
+import com.project.real_estate_project03_team02.service.helper.AdvertServiceHelper;
 import com.project.real_estate_project03_team02.service.helper.PageableHelper;
 import com.project.real_estate_project03_team02.service.user.UserService;
 import lombok.RequiredArgsConstructor;
 //import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -43,7 +45,7 @@ public class TourRequestService {
     private final TourRequestMapper tourRequestMapper;
 
     private final UserService userService;
-    private final AdvertService advertService;
+    private final AdvertServiceHelper advertServiceHelper;
 
     /**
      * Retrieves all tour requests associated with the authenticated user.
@@ -133,7 +135,7 @@ public class TourRequestService {
         checkTourRequestRequestDate(tourRequestRequest);
         TourRequest tourRequest = tourRequestMapper.mapTourRequestRequestToTourRequest(tourRequestRequest);
         tourRequest.setStatus(TourRequestStatus.PENDING);
-        Advert advert = advertService.findById(tourRequestRequest.getAdvertId());
+        Advert advert = advertServiceHelper.findById(tourRequestRequest.getAdvertId());
         tourRequest.setAdvertId(advert);
         User ownerUser = advert.getUserId();
         tourRequest.setOwnerUserId(ownerUser);
@@ -176,7 +178,7 @@ public class TourRequestService {
         }
         tourRequest = tourRequestMapper.mapTourRequestRequestToTourRequest(tourRequestRequest);
         tourRequest.setStatus(TourRequestStatus.PENDING);
-        Advert advert = advertService.findById(tourRequestRequest.getAdvertId());
+        Advert advert = advertServiceHelper.findById(tourRequestRequest.getAdvertId());
         tourRequest.setAdvertId(advert);
         tourRequest.setUpdatedAt(LocalDateTime.now());
         TourRequest savedTourRequest = tourRequestRepository.save(tourRequest);

--- a/src/main/java/com/project/real_estate_project03_team02/service/helper/AdvertServiceHelper.java
+++ b/src/main/java/com/project/real_estate_project03_team02/service/helper/AdvertServiceHelper.java
@@ -1,0 +1,22 @@
+package com.project.real_estate_project03_team02.service.helper;
+
+import com.project.real_estate_project03_team02.entity.concretes.business.Advert;
+import com.project.real_estate_project03_team02.exception.ResourceNotFoundException;
+import com.project.real_estate_project03_team02.payload.messages.ErrorMessages;
+import com.project.real_estate_project03_team02.repository.business.AdvertRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AdvertServiceHelper {
+
+  private final AdvertRepository advertRepository;
+
+
+  public Advert findById(Long advertId) {
+    return advertRepository.findById(advertId).orElseThrow(()->new ResourceNotFoundException(String.format(
+        ErrorMessages.NOT_FOUND_ADVERT_MESSAGE,advertId)));
+  }
+
+}


### PR DESCRIPTION
This commit introduces the use of AdvertServiceHelper for Advert findById method calls, replacing AdvertService to enhance modularity. This change has been applied across FavoritesService and TourRequestService. Also, in AdvertMapper, the mapping of tour requests to advert responses is removed for code cleanup.